### PR TITLE
hipModuleGetGlobal

### DIFF
--- a/include/hip/hip_runtime.inl
+++ b/include/hip/hip_runtime.inl
@@ -374,6 +374,17 @@ hipError_t hipModuleGetFunction(hipFunction_t *hfunc, hipModule_t hmod,
 #endif
 
 NV_HIP_DECORATOR
+hipError_t hipModuleGetGlobal(hipDeviceptr_t *dptr, size_t *bytes,
+					  hipModule_t hmod, const char *name)
+#ifdef NV_HIP_RUNTIME_LIB_MODE
+    ;
+#else
+{
+  return cuError2hipError(cuModuleGetGlobal(dptr, bytes, hmod, name));
+}
+#endif
+
+NV_HIP_DECORATOR
 hipError_t hipModuleUnload(hipModule_t hmod)
 #ifdef NV_HIP_RUNTIME_LIB_MODE
     ;

--- a/include/hip/hip_runtime.inl
+++ b/include/hip/hip_runtime.inl
@@ -56,7 +56,7 @@ typedef cudaDeviceProp hipDeviceProp_t;
 typedef cudaPointerAttributes hipPointerAttributes_t;
 typedef CUmodule hipModule_t;
 typedef CUfunction hipFunction_t;
-typedef void* hipDeviceptr_t;
+typedef CUdeviceptr hipDeviceptr_t;
 typedef CUmodule hipModule_t;
 
 NV_HIP_DECORATOR_HD inline hipError_t cudaError2hipError(cudaError_t error) {

--- a/include/hip/hip_runtime.inl
+++ b/include/hip/hip_runtime.inl
@@ -376,7 +376,7 @@ hipError_t hipModuleGetFunction(hipFunction_t *hfunc, hipModule_t hmod,
 
 NV_HIP_DECORATOR
 hipError_t hipModuleGetGlobal(hipDeviceptr_t *dptr, size_t *bytes,
-					  hipModule_t hmod, const char *name)
+                              hipModule_t hmod, const char *name)
 #ifdef NV_HIP_RUNTIME_LIB_MODE
     ;
 #else

--- a/include/hip/hip_runtime.inl
+++ b/include/hip/hip_runtime.inl
@@ -56,6 +56,7 @@ typedef cudaDeviceProp hipDeviceProp_t;
 typedef cudaPointerAttributes hipPointerAttributes_t;
 typedef CUmodule hipModule_t;
 typedef CUfunction hipFunction_t;
+typedef void* hipDeviceptr_t;
 typedef CUmodule hipModule_t;
 
 NV_HIP_DECORATOR_HD inline hipError_t cudaError2hipError(cudaError_t error) {


### PR DESCRIPTION
I have added hipModuleGetGlobal to hip_runtime.inl to not have errors when using hip-on-nv with PyHIP.